### PR TITLE
Custom Filter & JSON Logging Via Telemetry Subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1468,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1465,6 +1477,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,16 +353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,7 +1097,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-bunyan-formatter",
  "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1372,23 +1361,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tracing-bunyan-formatter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2445962f94a813b2aaea29ceeccb6dce9fd3aa5b1cb45595cde755b00d021ad"
-dependencies = [
- "gethostname",
- "log",
- "serde",
- "serde_json",
- "time",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,7 +1095,7 @@ checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "telemetry-subscribers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "camino",
  "console-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ tokio = { version = "1.21.2", features = [
 ] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
-tracing-bunyan-formatter = "0.3.3"
 tracing-chrome = { version = "0.7.0", optional = true }
 tracing-opentelemetry = { version = "0.18.0", optional = true }
 tracing-subscriber = { version = "0.3.15", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,28 @@ console-subscriber = { version = "0.1.6", optional = true }
 crossterm = "0.25.0"
 once_cell = "1.13.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"], optional = true }
-opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"], optional = true }
+opentelemetry-jaeger = { version = "0.17.0", features = [
+  "rt-tokio",
+], optional = true }
 prometheus = "0.13.1"
-tokio = { version = "1.21.2", features = ["sync", "macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.21.2", features = [
+  "sync",
+  "macros",
+  "rt",
+  "rt-multi-thread",
+] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-bunyan-formatter = "0.3.3"
 tracing-chrome = { version = "0.7.0", optional = true }
 tracing-opentelemetry = { version = "0.18.0", optional = true }
-tracing-subscriber = { version = "0.3.15", features = ["std", "time", "registry", "env-filter"] }
+tracing-subscriber = { version = "0.3.15", features = [
+  "std",
+  "time",
+  "registry",
+  "env-filter",
+  "json",
+] }
 
 [features]
 default = ["jaeger"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can also run the example and see output in ANSI color:
 
 ## Features
 - `jaeger` - this feature is enabled by default as it enables jaeger tracing
-- `json` - Bunyan formatter - JSON log output, optional
+- `json` - uses the JSON feature from the [tracing crate](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html), optional
 - `tokio-console` - [Tokio-console](https://github.com/tokio-rs/console) subscriber, optional
 - `chrome` - enables use of `chrome://tracing` to visualize output, optional
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,6 @@ impl FilterHandle {
 fn get_output(log_file: Option<String>) -> (NonBlocking, WorkerGuard) {
     if let Some(logfile_prefix) = log_file {
         let file_appender = tracing_appender::rolling::daily("", logfile_prefix);
-        println!("The file appender {:?}", file_appender);
         tracing_appender::non_blocking(file_appender)
     } else {
         tracing_appender::non_blocking(stderr())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,11 +119,10 @@ use std::{
 use tracing::metadata::LevelFilter;
 use tracing::Level;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::{
-    filter,
+    filter::{self, FilterExt},
     fmt::{self, format::FmtSpan},
-    layer::SubscriberExt,
+    layer::{Filter, SubscriberExt},
     reload,
     util::SubscriberInitExt,
     EnvFilter, Layer, Registry,
@@ -171,6 +170,8 @@ pub struct TelemetryConfig {
     pub prom_registry: Option<prometheus::Registry>,
     /// Pass in any additional custom layers that the consumer wants their subscriber to be created with
     pub custom_layers: Vec<Box<dyn Layer<Registry> + Send + Sync + 'static>>,
+    /// Pass in any custom filter that will be applied along with the default filter
+    pub custom_filter: Option<Box<dyn Filter<Registry> + Send + Sync>>,
 }
 
 #[must_use]
@@ -202,6 +203,7 @@ impl FilterHandle {
 fn get_output(log_file: Option<String>) -> (NonBlocking, WorkerGuard) {
     if let Some(logfile_prefix) = log_file {
         let file_appender = tracing_appender::rolling::daily("", logfile_prefix);
+        println!("The file appender {:?}", file_appender);
         tracing_appender::non_blocking(file_appender)
     } else {
         tracing_appender::non_blocking(stderr())
@@ -264,6 +266,7 @@ impl TelemetryConfig {
             crash_on_panic: false,
             prom_registry: None,
             custom_layers: Vec::new(),
+            custom_filter: None,
         }
     }
 
@@ -292,6 +295,19 @@ impl TelemetryConfig {
         L: Layer<Registry> + Send + Sync + 'static,
     {
         self.custom_layers.push(Box::new(layer));
+        self
+    }
+
+    pub fn with_json_logs(mut self) -> Self {
+        self.json_log_output = true;
+        self
+    }
+
+    pub fn with_custom_filter<F>(mut self, filter: F) -> Self
+    where
+        F: Filter<Registry> + Send + Sync + 'static,
+    {
+        self.custom_filter = Some(Box::new(filter));
         self
     }
 
@@ -400,32 +416,31 @@ impl TelemetryConfig {
         }
 
         let (nb_output, worker_guard) = get_output(config.log_file.clone());
-        if config.json_log_output {
-            // See https://www.lpalmieri.com/posts/2020-09-27-zero-to-production-4-are-we-observable-yet/#5-7-tracing-bunyan-formatter
-            // Also Bunyan layer addes JSON logging for tracing spans with duration information
-            let json_layer = JsonStorageLayer
-                .and_then(
-                    BunyanFormattingLayer::new(config.service_name, nb_output)
-                        .with_filter(log_filter),
-                )
-                .boxed();
-            layers.push(json_layer);
+
+        //  Create the base format layer
+        let fmt_layer = fmt::layer().with_writer(nb_output);
+        let fmt_layer = if config.json_log_output {
+            let layer = fmt_layer.json().flatten_event(true);
+            if let Some(custom_filter) = config.custom_filter {
+                layer.with_filter(log_filter.and(custom_filter)).boxed()
+            } else {
+                layer.with_filter(log_filter).boxed()
+            }
         } else {
-            // Output to file or to stderr with ANSI colors
             let span_events = if config.span_log_output {
                 FmtSpan::NEW | FmtSpan::CLOSE
             } else {
                 FmtSpan::NONE
             };
-            let fmt_layer = fmt::layer()
+            fmt_layer
                 .with_ansi(config.log_file.is_none() && stderr().is_tty())
                 .with_span_events(span_events)
-                .with_writer(nb_output)
                 .with_filter(log_filter)
-                .boxed();
-            layers.push(fmt_layer);
-        }
+                .boxed()
+        };
+        layers.push(fmt_layer);
 
+        //  Add custom layers
         for layer in config.custom_layers {
             layers.push(layer);
         }


### PR DESCRIPTION
This PR:

* adds a builder method to allow supporting custom filter for the base layer
* switches out the json layer that was using the tracing bunyan formatter to use the json formatting layer provided by the tracing crate itself.

It can now be used like this

```
let (_guards, _filter_handle) = TelemetryConfig::new("my-app")
            .with_json_logs()
            .with_log_file("logs.json")
            .with_custom_filter(my_custom_filter)
            .with_layer(my_custom_layer)
            .init();
        std::mem::forget(_guards);
        std::mem::forget(_filter_handle);
```